### PR TITLE
Update examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,15 +60,15 @@ specifying the file to launch
 and the branch to use:
 ```bash
 nbgitpuller-link \
-    --jupyterhub-url=https://csdms.rc.colorado.edu \
-    --repository-url=https://github.com/csdms/espin \
+    --jupyterhub-url=https://lab.openearthscape.org \
+    --repository-url=https://github.com/csdms/ivy \
     --branch=main \
-    --launch-path=lessons/jupyter/index.ipynb
+    --launch-path=lessons/bmi/index.ipynb
 ```
 
 The resulting link:
 ```bash
-https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=tree%2Fespin%2Flessons%2Fjupyter%2Findex.ipynb&branch=main
+https://lab.openearthscape.org/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fivy&urlpath=tree%2Fivy%2Flessons%2Fbmi%2Findex.ipynb&branch=main
 ```
 
 ### Python
@@ -81,10 +81,10 @@ from nbgitpuller_link import Link
 Generate a link though a `Link` instance:
 ```python
 linker = Link(
-    jupyterhub_url="https://csdms.rc.colorado.edu",
-    repository_url="https://github.com/csdms/espin",
+    jupyterhub_url="https://lab.openearthscape.org",
+    repository_url="https://github.com/csdms/ivy",
     branch="main",
-    launch_path="lessons/jupyter/index.ipynb",
+    launch_path="lessons/bmi/index.ipynb",
     interface="lab",
     )
 ```
@@ -96,5 +96,5 @@ print("The nbgitpuller link is:\n{}".format(linker.link))
 ```
 ```
 The nbgitpuller link is:
-https://csdms.rc.colorado.edu/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fespin&urlpath=lab%2Ftree%2Fespin%2Flessons%2Fjupyter%2Findex.ipynb%3Fautodecode&branch=main
+https://lab.openearthscape.org/hub/user-redirect/git-pull?repo=https%3A%2F%2Fgithub.com%2Fcsdms%2Fivy&urlpath=lab%2Ftree%2Fivy%2Flessons%2Fbmi%2Findex.ipynb%3Fautodecode&branch=main
 ```

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ Note that this example uses the JupyterLab interface.
 
 The `link` property holds the URL:
 ```python
-print("The nbgitpuller link is:\n{}".format(linker.link))
+print(f"The nbgitpuller link is:\n{linker.link}")
 ```
 ```
 The nbgitpuller link is:

--- a/examples/nbgitpuller_link_ex.py
+++ b/examples/nbgitpuller_link_ex.py
@@ -1,10 +1,10 @@
 """Example of constructing an nbgitpuller link."""
 from nbgitpuller_link import Link
 
-HUB = "https://csdms.rc.colorado.edu"
-REPO = "https://github.com/csdms/espin"
+HUB = "https://lab.openearthscape.org"
+REPO = "https://github.com/csdms/ivy"
 BRANCH = "main"
-FILE = "lessons/jupyter/index.ipynb"
+FILE = "lessons/bmi/index.ipynb"
 INTERFACE = "lab"
 
 
@@ -16,4 +16,4 @@ linker = Link(
     interface=INTERFACE,
 )
 
-print("The nbgitpuller link is:\n{}".format(linker.link))
+print(f"The nbgitpuller link is:\n{linker.link}")

--- a/examples/nbgitpuller_link_ex.sh
+++ b/examples/nbgitpuller_link_ex.sh
@@ -1,10 +1,11 @@
 #! /usr/bin/env bash
-# Example of constructing a link through the nbgitpuller CLI.
+# An example of constructing a link through the nbgitpuller CLI.
 
-HUB=https://csdms.rc.colorado.edu
-REPO=https://github.com/csdms/espin
+HUB=https://lab.openearthscape.org
+REPO=https://github.com/csdms/ivy
 BRANCH=main
-FILE=lessons/jupyter/index.ipynb  # Note: escape space in path with backslash
+FILE=lessons/bmi/index.ipynb  # Note: escape space in path with backslash
+INTERFACE=notebook
 
 nbgitpuller-link --version
 nbgitpuller-link --help
@@ -13,4 +14,5 @@ nbgitpuller-link \
     --jupyterhub-url=$HUB \
     --repository-url=$REPO \
     --branch=$BRANCH \
-    --launch-path="$FILE"
+    --launch-path="$FILE" \
+    --interface=$INTERFACE


### PR DESCRIPTION
The *nbgitpuller-link* examples used an old Hub URL that no longer exists. To model a real experience, I've updated the examples to use the OpenEarthscape _lab_ Hub URL.